### PR TITLE
feat(notes): enable dynamic note suggestions by integrating API with editor

### DIFF
--- a/packages/morph/components/editor.tsx
+++ b/packages/morph/components/editor.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import axios from "axios"
 import CodeMirror from "@uiw/react-codemirror"
 import { markdown as markdownExtension } from "@codemirror/lang-markdown"
 import { languages } from "@codemirror/language-data"
@@ -10,11 +11,15 @@ import { EditorView } from "@codemirror/view"
 import { vim } from "@replit/codemirror-vim"
 import { inlineMarkdownExtension } from "./markdown-inline"
 import { AppSidebar } from "./app-sidebar"
-import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar"
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar"
 import { Toolbar } from "./toolbar"
 import { drag } from "d3-drag"
 import { select } from "d3-selection"
-import { useRef, useState } from "react"
+import { useRef, useState, useEffect, useCallback, useMemo } from "react"
 import usePersistedSettings from "@/hooks/use-persisted-settings"
 
 interface Note {
@@ -22,73 +27,15 @@ interface Note {
   content: string
 }
 
+interface Suggestion {
+  suggestion: string
+  relevance: number
+}
+
 interface DraggableNoteProps extends Note {
   onDrop: (note: Note, droppedOverEditor: boolean) => void
   editorRef: React.RefObject<HTMLDivElement | null>
 }
-
-const SAMPLE_NOTES = [
-  {
-    title: "Jogging",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "games",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "Jogging",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "Examination",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "Classes",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "Race",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "Speech",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "Party",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "Reminder",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "games",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "Speech",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-  {
-    title: "Party",
-    content:
-      "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.",
-  },
-]
 
 const initialMarkdown = `---
 id: mechanistic interpretability
@@ -253,30 +200,34 @@ function DraggableNoteCard({ title, content, onDrop, editorRef }: DraggableNoteP
   )
 }
 
+
 export default function Editor() {
   const [showNotes, setShowNotes] = useState(true)
   const [markdownContent, setMarkdownContent] = useState(initialMarkdown)
   const { settings } = usePersistedSettings()
-  const [notes, setNotes] = useState<Note[]>(SAMPLE_NOTES)
+  const [notes, setNotes] = useState<Note[]>([])
   const editorRef = useRef<HTMLDivElement>(null)
+  const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
-  const handleChange = React.useCallback((value: string) => {
+  const handleChange = useCallback((value: string) => {
     setMarkdownContent(value)
   }, [])
 
-  const toggleNotes = React.useCallback(() => {
+  const toggleNotes = useCallback(() => {
     setShowNotes((prev) => !prev)
   }, [])
 
-  const handleNoteDrop = React.useCallback((note: Note, droppedOverEditor: boolean) => {
+  const handleNoteDrop = useCallback((note: Note, droppedOverEditor: boolean) => {
     if (droppedOverEditor) {
       setNotes((prevNotes) =>
-        prevNotes.filter((n) => !(n.title === note.title && n.content === note.content)),
+        prevNotes.filter(
+          (n) => !(n.title === note.title && n.content === note.content)
+        )
       )
     }
   }, [])
 
-  const editorExtensions = React.useMemo(() => {
+  const editorExtensions = useMemo(() => {
     const extensions = [
       markdownExtension({ base: markdownLanguage, codeLanguages: languages }),
       inlineMarkdownExtension,
@@ -287,6 +238,55 @@ export default function Editor() {
     }
     return extensions
   }, [settings.vimMode])
+
+
+  const fetchNewNotes = async (content: string): Promise<Note[]> => {
+    try {
+      const apiEndpoint = "<URL>"
+      const response = await axios.post<Suggestion[]>(
+        `${apiEndpoint}/suggests`,
+        {
+          essay: content,
+          num_suggestions: 5,
+          max_tokens: 4096,
+        },
+        {
+          headers: {
+            Accept: "text/event-stream",
+            "Content-Type": "application/json",
+          },
+        }
+      )
+      const data = Array.isArray(response.data) ? response.data : [];
+      const newNotes = data.map((item, index) => ({
+        title: `Note ${index + 1}`,
+        content: item.suggestion,
+      }))
+      return newNotes
+    } catch (error) {
+      console.error("Error fetching suggestions:", error)
+      return []
+    }
+  }
+
+  useEffect(() => {
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current)
+    }
+    debounceTimeoutRef.current = setTimeout(() => {
+      fetchNewNotes(markdownContent).then((newNotes) => {
+        if (newNotes.length > 0) {
+          setNotes(newNotes)
+        }
+      })
+    }, 1000)
+
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current)
+      }
+    }
+  }, [markdownContent])
 
   return (
     <div className={settings.theme === "dark" ? "dark" : ""}>

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -28,6 +28,7 @@
     "@replit/codemirror-vim": "^6.2.1",
     "@tailwindcss/typography": "^0.5.16",
     "@uiw/react-codemirror": "^4.23.7",
+    "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3-drag": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       '@uiw/react-codemirror':
         specifier: ^4.23.7
         version: 4.23.7(@babel/runtime@7.26.7)(@codemirror/autocomplete@6.18.4)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.8)(@codemirror/state@6.5.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.2)(codemirror@6.0.1)(react-dom@19.0.0)(react@19.0.0)
+      axios:
+        specifier: ^1.7.9
+        version: 1.7.9
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3634,6 +3637,16 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -4990,6 +5003,16 @@ packages:
 
   /flexsearch@0.7.43:
     resolution: {integrity: sha512-c5o/+Um8aqCSOXGcZoqZOm+NqtVwNsvVpWv6lfmSclU954O3wvQKxxK8zj74fPaSJbXpSLTs4PRhh+wnoCXnKg==}
+    dev: false
+
+  /follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
     dev: false
 
   /for-each@0.3.4:
@@ -7088,6 +7111,10 @@ packages:
 
   /property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
+    dev: false
+
+  /proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: false
 
   /psl@1.9.0:


### PR DESCRIPTION
Connected the editor to an API for fetching and displaying note suggestions dynamically as users type.

### Overview
- Integrated API with dynamic suggestions based on content.  
- Added a debounce mechanism to limit excessive API calls.  
- Implemented error handling for empty or failed responses.

> [!NOTE]  
> The endpoint is set to `<URL>` in the code.  Replace `<URL>` with the actual API endpoint when deploying.
