### PR TITLE
feat(notes): implement drag and drop for sticky note-like transfer

### DIFF
--- a/packages/morph/components/editor-notes.tsx
+++ b/packages/morph/components/editor-notes.tsx
@@ -1,46 +1,66 @@
-import * as React from "react"
-import { useDrop } from "react-dnd"
+import React, { useRef } from "react"
+import { useDrop, useDragLayer } from "react-dnd"
 import { NOTES_DND_TYPE, type Note } from "@/lib/notes"
 import { useNotes } from "@/context/notes-context"
-import { cn } from "@/lib/utils"
+import { NoteCard } from "@/components/note-card"
 
-export function EditorNotes() {
+export function EditorDropZone() {
   const { editorNotes, moveNoteToEditor } = useNotes()
+  const containerRef = useRef<HTMLDivElement>(null)
 
-  const [{ isOver, isOverCurrent }, drop] = useDrop(() => ({
+  const [{ isOver }, drop] = useDrop({
     accept: NOTES_DND_TYPE,
     drop: (item: Note, monitor) => {
-      if (monitor.didDrop()) {
-        return
+      if (!containerRef.current) return
+      const clientOffset = monitor.getClientOffset()
+      if (!clientOffset) return
+      const boundingRect = containerRef.current.getBoundingClientRect()
+      const position = {
+        x: clientOffset.x - boundingRect.left,
+        y: clientOffset.y - boundingRect.top,
       }
-      moveNoteToEditor(item.id)
-      return { noteId: item.id, targetId: 'editor' }
+
+      console.log("Note dropped at position:", position)
+
+      moveNoteToEditor(item.id, position)
+      
+      return { noteId: item.id, targetId: "editor" }
     },
     collect: (monitor) => ({
       isOver: monitor.isOver(),
-      isOverCurrent: monitor.isOver({ shallow: true }),
     }),
+  })
+
+  const { isDragging } = useDragLayer((monitor) => ({
+    isDragging: monitor.isDragging(),
   }))
+
+  drop(containerRef)
 
   return (
     <div
-      ref={drop}
-      className={cn(
-        "fixed top-4 right-4 flex flex-col gap-2 z-50 w-48",
-        isOverCurrent && "ring-2 ring-primary ring-offset-2",
-        isOver && !isOverCurrent && "ring-2 ring-secondary ring-offset-2"
-      )}
+      ref={containerRef}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 100,
+        pointerEvents: isDragging ? "auto" : "none",
+      }}
+      className={isOver ? "border-2 border-blue-500" : ""}
     >
       {editorNotes.map((note) => (
         <div
           key={note.id}
-          className={cn(
-            "p-2 shadow-sm cursor-pointer text-sm rounded border border-border",
-            note.color,
-            "text-gray-800 dark:text-gray-200"
-          )}
+          style={{
+            position: "absolute",
+            top: note.position?.y ?? 0,
+            left: note.position?.x ?? 0,
+          }}
         >
-          <p className="line-clamp-1">{note.content}</p>
+          <NoteCard note={note} className="w-48" />
         </div>
       ))}
     </div>

--- a/packages/morph/components/editor-notes.tsx
+++ b/packages/morph/components/editor-notes.tsx
@@ -4,7 +4,7 @@ import { NOTES_DND_TYPE, type Note } from "@/lib/notes"
 import { useNotes } from "@/context/notes-context"
 import { NoteCard } from "@/components/note-card"
 
-export function EditorDropZone() {
+export function EditorNotes() {
   const { editorNotes, moveNoteToEditor } = useNotes()
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -23,7 +23,7 @@ export function EditorDropZone() {
       console.log("Note dropped at position:", position)
 
       moveNoteToEditor(item.id, position)
-      
+
       return { noteId: item.id, targetId: "editor" }
     },
     collect: (monitor) => ({

--- a/packages/morph/components/editor.tsx
+++ b/packages/morph/components/editor.tsx
@@ -29,7 +29,7 @@ import { SearchCommand } from "@/components/search-command"
 import { DndProvider } from "react-dnd"
 import { HTML5Backend } from "react-dnd-html5-backend"
 import { NotesProvider } from "@/context/notes-context"
-import { EditorDropZone } from "@/components/editor-notes"
+import { EditorNotes } from "@/components/editor-notes"
 import { generatePastelColor } from "@/lib/notes"
 import { notesService } from "@/services/notes-service"
 import { db, type Note, type Vault, type FileSystemTreeNode } from "@/db"
@@ -167,9 +167,9 @@ export default memo(function Editor({ vaultId, vaults }: EditorProps) {
         title: "Dummy Note 3",
         content: "This is dummy note content number 3.",
       },
-    ]);
-  };
-  
+    ])
+  }
+
   /*
   const fetchNewNotes = async (content: string): Promise<GeneratedNote[]> => {
     try {
@@ -442,7 +442,7 @@ export default memo(function Editor({ vaultId, vaults }: EditorProps) {
               </header>
               <section className="flex h-[calc(100vh-104px)] gap-10 m-4">
                 <div className="flex-1 relative border">
-                  <EditorDropZone />
+                  <EditorNotes />
                   <div
                     className={`editor-mode absolute inset-0 ${isEditMode ? "block" : "hidden"}`}
                   >
@@ -472,7 +472,6 @@ export default memo(function Editor({ vaultId, vaults }: EditorProps) {
                           codeMirrorViewRef.current = view
                         }}
                       />
-                      
                     </div>
                   </div>
                   <div
@@ -519,32 +518,32 @@ export default memo(function Editor({ vaultId, vaults }: EditorProps) {
                               onDragEnd={(e) => {
                                 // Remove note from note panel when note note dropped onto editor
                                 if (e.dataTransfer.dropEffect === "move") {
-                                  const draggedNote = notes[index];
-                                  setNotes((prev) => prev.filter((_, i) => i !== index));
+                                  const draggedNote = notes[index]
+                                  setNotes((prev) => prev.filter((_, i) => i !== index))
                                   // Transfer note content to editor when dropped (Not neccessary if whole note needed to be added on top of editor)
                                   if (codeMirrorViewRef.current) {
-                                    const editor = codeMirrorViewRef.current;
-                                    const cursorPosition = editor.state.selection.main.head;
+                                    const editor = codeMirrorViewRef.current
+                                    const cursorPosition = editor.state.selection.main.head
                                     editor.dispatch({
                                       changes: {
                                         from: cursorPosition,
                                         insert: draggedNote.content,
                                       },
-                                    });
+                                    })
                                   }
                                 }
                               }}
                             >
                               <NoteCard
-                              className="w-full"
-                              note={{
-                                id: note.id,
-                                content: note.content,
-                                color: note.color ?? generatePastelColor(),
-                                fileId: currentFile,
-                                isInEditor: false,
-                                createdAt: note.createdAt ?? new Date(),
-                              }}
+                                className="w-full"
+                                note={{
+                                  id: note.id,
+                                  content: note.content,
+                                  color: note.color ?? generatePastelColor(),
+                                  fileId: currentFile,
+                                  isInEditor: false,
+                                  createdAt: note.createdAt ?? new Date(),
+                                }}
                               />
                             </div>
                           ))}

--- a/packages/morph/components/editor.tsx
+++ b/packages/morph/components/editor.tsx
@@ -154,24 +154,6 @@ export default memo(function Editor({ vaultId, vaults }: EditorProps) {
   )
 
   const fetchNewNotes = async (content: string): Promise<GeneratedNote[]> => {
-    return Promise.resolve([
-      {
-        title: "Dummy Note 1",
-        content: "This is dummy note content number 1.",
-      },
-      {
-        title: "Dummy Note 2",
-        content: "This is dummy note content number 2.",
-      },
-      {
-        title: "Dummy Note 3",
-        content: "This is dummy note content number 3.",
-      },
-    ])
-  }
-
-  /*
-  const fetchNewNotes = async (content: string): Promise<GeneratedNote[]> => {
     try {
       const apiEndpoint = process.env.NEXT_PUBLIC_API_ENDPOINT
       if (!apiEndpoint) {
@@ -207,7 +189,7 @@ export default memo(function Editor({ vaultId, vaults }: EditorProps) {
       throw error
     }
   }
-  */
+
   const handleSave = useCallback(async () => {
     try {
       let targetHandle = currentFileHandle

--- a/packages/morph/components/note-card.tsx
+++ b/packages/morph/components/note-card.tsx
@@ -16,9 +16,11 @@ export const NoteCard = React.memo(function NoteCard({ note, className }: NoteCa
       isDragging: monitor.isDragging(),
     }),
     end: (item, monitor) => {
-      const dropResult = monitor.getDropResult<{ noteId: string; targetId: string }>()
-      if (dropResult) {
-        // Handle any cleanup if needed
+      const dropResult = monitor.getDropResult<{ noteId: string; targetId: string }>();
+      if (dropResult?.targetId === "editor") {
+        // Note was successfully dropped in editor
+      } else {
+        // Return note to original position if dropped elsewhere
       }
     },
   }))

--- a/packages/morph/db.ts
+++ b/packages/morph/db.ts
@@ -50,6 +50,7 @@ export interface Note {
   fileId: string
   vaultId: string
   isInEditor: boolean
+  position?: { x: number; y: number }
   createdAt: Date
   lastModified: Date
 }

--- a/packages/morph/next.config.ts
+++ b/packages/morph/next.config.ts
@@ -13,7 +13,6 @@ export default MillionLint.next({
   })({
     assetPrefix: process.env.NODE_ENV === "production" ? undefined : "",
     transpilePackages: ["next-plausible", "katex", "mermaid"],
-    devIndicators: { appIsrStatus: false },
     webpack(config) {
       config.module.rules.push({
         test: /\.(woff|woff2|eot|ttf|otf)$/,


### PR DESCRIPTION
### Overview
- Store note positions in the database upon drop to maintain their exact placement in the editor.
- Update `EditorDropZone` to calculate drop coordinates relative to the editor board.
- Adjusted `moveNoteToEditor` to update note state (position and isInEditor flag) on drop.
- Notes appear in the editor overlay but are not yet stacked on top (sticky note behavior pending).
- Remove the note instance from the notes panel once it is successfully dropped in the editor to prevent duplicate entries.
- Create dummy notes for testing purposes to facilitate debugging and verifying the drag-and-drop functionality within the editor.






