### PR TITLE
feat: add mobile support notification popup on landing page

### DIFF
--- a/packages/morph/app/page.tsx
+++ b/packages/morph/app/page.tsx
@@ -5,8 +5,19 @@ import { EnterIcon, DoubleArrowRightIcon } from "@radix-ui/react-icons"
 import { PixelatedScene } from "@/components/landing"
 import { VaultButton } from "@/components/ui/button"
 import { PageTransition } from "@/components/landing/page-transition"
+import { useEffect, useState } from "react"
 
 export default function LandingPage() {
+  const [showMobilePopup, setShowMobilePopup] = useState(false)
+
+  useEffect(() => {
+    const isMobile = /Mobi|Android/i.test(navigator.userAgent)
+
+    if (isMobile) {
+      setShowMobilePopup(true)
+    }
+  }, [])
+
   return (
     <PageTransition>
       <div className="relative h-screen w-full bg-background flex flex-col items-center justify-center">
@@ -26,6 +37,22 @@ export default function LandingPage() {
             </div>
           </div>
         </div>
+        {showMobilePopup && (
+            <div className="fixed inset-0 z-[100] flex flex-col items-center justify-center bg-black/50 p-5">
+              <div className="bg-white p-6 rounded shadow-md text-center">
+                <h2 className="text-lg font-bold mb-2">Mobile Support Coming Soon</h2>
+                <p className="mb-4">
+                In the meantime, please access the vault editor using a desktop device.
+                </p>
+                <a
+                href="https://github.com/aarnphm/morph"
+                className="bg-green-500 text-white px-4 py-2 rounded"
+                >
+                Go to GitHub
+                </a>
+              </div>
+            </div>
+        )}
       </div>
     </PageTransition>
   )


### PR DESCRIPTION
Add a popup for mobile users on the landing page notifying that mobile support is coming soon, with a button linking to the GitHub repository.
